### PR TITLE
Ignore any line containing uuid, since FortiOS 5.2

### DIFF
--- a/pyFG/forticonfig.py
+++ b/pyFG/forticonfig.py
@@ -349,8 +349,12 @@ class FortiConfig(object):
 
         if output.__class__ is str or output.__class__ is unicode:
             output = output.splitlines()
+         
+        ignore_lines = ['uuid']
 
         for line in output:
+            if line in ignore_lines:
+                continue
             line = line.strip()
             result = regexp.match(line)
 


### PR DESCRIPTION
Since FortiOS 5.2 was released, Fortinet has added uuid values to for example:
firewall policies, firewall addresses, and firewall address groups
When using pyFG, it used to try to unset all the uuid's, breaking the commit to the firewall.
Now it will simply ignore ANY line containing "uuid" in the config, which is a bit risky - but for now it's the easy way to do it.
