### PR TITLE
Fix uuid-code since last commit, and check for errors 3 times

### DIFF
--- a/pyFG/forticonfig.py
+++ b/pyFG/forticonfig.py
@@ -350,10 +350,8 @@ class FortiConfig(object):
         if output.__class__ is str or output.__class__ is unicode:
             output = output.splitlines()
          
-        ignore_lines = ['uuid']
-
         for line in output:
-            if line in ignore_lines:
+            if 'uuid' in line:
                 continue
             line = line.strip()
             result = regexp.match(line)

--- a/pyFG/fortios.py
+++ b/pyFG/fortios.py
@@ -291,12 +291,15 @@ class FortiOS(object):
             # We retry if we see codes -3 (some object you are trying to assign does not exist yet) and
             # code -23 (you are trying to delete an object which is assigned to some other object).
             retry_codes = [-3, -23]
-            for wc in wrong_commands:
-                if int(wc[0]) in retry_codes:
-                    config_text = self.compare_config()
-                    wrong_commands = _execute(config_text)
-                    self._reload_config(reload_original_config=False)
-                    break
+            retries = 3
+            while retries > 0:
+                retries -= 1
+                for wc in wrong_commands:
+                    if int(wc[0]) in retry_codes:
+                        config_text = self.compare_config()
+                        wrong_commands = _execute(config_text)
+                        self._reload_config(reload_original_config=False)
+                        break            
 
         if len(wrong_commands) > 0:
             exit_code = -2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ reqs = [str(ir.req) for ir in install_reqs]
 
 setup(
     name = "pyfg",  
-    version = "0.42",
+    version = "0.43",
     packages = find_packages(),
     author = "XNET",
     author_email = "dbarroso@spotify.com",


### PR DESCRIPTION
UUID:
To do it as we did before - having a list of text that should be ignored, we would have to do a proper loop. Instead we are doing a more quick and dirty fix.

Fail retries:
So, in FortiOS, if you try to remove a firewall address, firewall address group, and then a firewall policy - that is using said firewall address group - it will fail, with error code -23.
In pyFG we are watching out for this, and retrying the failed lines. However, if you also try to delete said firewall address group AND the address'es inside it, we do not catch that - until now.
We are simply trying to run the failed lines more times instead. Also a bit dirty, but it does the job.
