### PR TITLE
Ignore any line containing snmp-index

### DIFF
--- a/pyFG/forticonfig.py
+++ b/pyFG/forticonfig.py
@@ -353,6 +353,8 @@ class FortiConfig(object):
         for line in output:
             if 'uuid' in line:
                 continue
+            if 'snmp-index' in line:
+                continue
             line = line.strip()
             result = regexp.match(line)
 


### PR DESCRIPTION
Same as for UUID's:
This is generated by the system, and right now the easiest solution is to ignore the whole line - otherwise it will be unset (reset) on every run.
