### PR TITLE
Support for ~/.ssh/config to use the ProxyPass options in there

### DIFF
--- a/docs/ssh_config.rst
+++ b/docs/ssh_config.rst
@@ -1,0 +1,33 @@
+SSH Config
+==========
+
+You can now store some of the access details for your FortiGate appliacnes
+inside the ~/.ssh/config of the user. Currently supported:
+
+- Username
+- Hostname
+- Proxy Command
+- IdentityFile
+
+Example 1
+---------
+
+Simple "alias" where us you would use the 'hostname' "fortigate" inside your
+scripts instead of the IP address. Handy if you do not have a DNS server.
+
+Host fortigate
+  Hostname 192.168.1.1
+  User admin
+
+
+Example 2
+---------
+
+A bit more complex whereas you need go via a SSH proxy server to reach the 
+appliance
+
+Host fortigate
+  Hostname 192.168.1.1
+  User admin
+  ProxyCommand ssh user@10.10.10.1 nc %h %p
+

--- a/docs/ssh_config.rst
+++ b/docs/ssh_config.rst
@@ -12,7 +12,7 @@ inside the ~/.ssh/config of the user. Currently supported:
 Example 1
 ---------
 
-Simple "alias" where us you would use the 'hostname' "fortigate" inside your
+Simple "alias" whereas you would use the 'hostname' "fortigate" inside your
 scripts instead of the IP address. Handy if you do not have a DNS server.
 
 Host fortigate
@@ -23,7 +23,7 @@ Host fortigate
 Example 2
 ---------
 
-A bit more complex whereas you need go via a SSH proxy server to reach the 
+A bit more complex for when you need go via a SSH proxy server to reach the 
 appliance
 
 Host fortigate

--- a/pyFG/fortios.py
+++ b/pyFG/fortios.py
@@ -62,13 +62,6 @@ class FortiOS(object):
         self.ssh = paramiko.SSHClient()
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
-        if os.path.exists(os.path.expanduser("~/.ssh/config")):
-          ssh_config = paramiko.SSHConfig()
-          user_config_file = os.path.expanduser("~/.ssh/config")
-          with open(user_config_file) as f:
-            ssh_config.parse(f)
-          f.close()
-
         cfg = {
           'hostname': self.hostname, 
           'timeout': 10,
@@ -76,11 +69,18 @@ class FortiOS(object):
           'password': self.password,
           'key_filename': self.keyfile
         }
-        host_conf = ssh_config.lookup(self.hostname)
-        if host_conf:
-          if 'proxycommand' in host_conf:
-            cfg['sock'] = paramiko.ProxyCommand(host_conf['proxycommand'])
 
+        if os.path.exists(os.path.expanduser("~/.ssh/config")):
+          ssh_config = paramiko.SSHConfig()
+          user_config_file = os.path.expanduser("~/.ssh/config")
+          with open(user_config_file) as f:
+            ssh_config.parse(f)
+          f.close()
+
+          host_conf = ssh_config.lookup(self.hostname)
+          if host_conf:
+            if 'proxycommand' in host_conf:
+              cfg['sock'] = paramiko.ProxyCommand(host_conf['proxycommand'])
 
         self.ssh.connect(**cfg)
 

--- a/pyFG/fortios.py
+++ b/pyFG/fortios.py
@@ -6,6 +6,7 @@ import exceptions
 import paramiko
 import StringIO
 import re
+import os
 from difflib import Differ
 
 import logging
@@ -61,13 +62,27 @@ class FortiOS(object):
         self.ssh = paramiko.SSHClient()
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
-        self.ssh.connect(
-            self.hostname,
-            timeout=10,
-            username=self.username,
-            password=self.password,
-            key_filename=self.keyfile
-        )
+        if os.path.exists(os.path.expanduser("~/.ssh/config")):
+          ssh_config = paramiko.SSHConfig()
+          user_config_file = os.path.expanduser("~/.ssh/config")
+          with open(user_config_file) as f:
+            ssh_config.parse(f)
+          f.close()
+
+        cfg = {
+          'hostname': self.hostname, 
+          'timeout': 10,
+          'username': self.username,
+          'password': self.password,
+          'key_filename': self.keyfile
+        }
+        host_conf = ssh_config.lookup(self.hostname)
+        if host_conf:
+          if 'proxycommand' in host_conf:
+            cfg['sock'] = paramiko.ProxyCommand(host_conf['proxycommand'])
+
+
+        self.ssh.connect(**cfg)
 
     def close(self):
         """

--- a/pyFG/fortios.py
+++ b/pyFG/fortios.py
@@ -81,6 +81,12 @@ class FortiOS(object):
           if host_conf:
             if 'proxycommand' in host_conf:
               cfg['sock'] = paramiko.ProxyCommand(host_conf['proxycommand'])
+            if 'user' in host_conf:
+              cfg['username'] = host_conf['user']
+            if 'identityfile' in host_conf:
+              cfg['key_filename'] = host_conf['identityfile']
+            if 'hostname' in host_conf:
+              cfg['hostname'] = host_conf['hostname']
 
         self.ssh.connect(**cfg)
 


### PR DESCRIPTION
I don't have direct access to the FortiGate. My connections go via a jump server which I can proxy using ProxyPass on my ~/.ssh/config

I'm using this configuration successfully.
