### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This API allows you to interact with a device runnine FortiOS in a sane way. Wit
 Documentation
 =============
 
-You can find the documentation on [Read the Docs](http://pyfg.readthedocs.org/en/latest/index.html).
+You can find the documentation on [Read the Docs](https://pyfg.readthedocs.io/en/latest/index.html).
 
 Installation
 ============


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
