### PR TITLE
Fix #18

### DIFF
--- a/pyFG/py23_compat.py
+++ b/pyFG/py23_compat.py
@@ -4,10 +4,10 @@ from __future__ import unicode_literals
 
 import sys
 
-PY2 = sys.version_info.major == 2
-PY3 = sys.version_info.major == 3
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
 
-if sys.version_info.major == 3:
+if sys.version_info[0] == 3:
     string_types = (str,)
     text_type = str
 else:


### PR DESCRIPTION
This fix #18 bug.


Lib is not working with python 2.6 & centos 6:

```
from pyFG import py23_compat
File "/usr/lib/python2.6/site-packages/pyFG/py23_compat.py", line 7
PY2 = sys.version_info.major == 2
AttributeError: 'tuple' object has no attribute 'major'
```

