### PR TITLE
Do not overwrite user argument with setting from ssh config

### DIFF
--- a/pyFG/fortios.py
+++ b/pyFG/fortios.py
@@ -93,7 +93,7 @@ class FortiOS(object):
             if host_conf:
                 if 'proxycommand' in host_conf:
                     cfg['sock'] = paramiko.ProxyCommand(host_conf['proxycommand'])
-                if 'user' in host_conf:
+                if 'user' in host_conf and not self.username:
                     cfg['username'] = host_conf['user']
                 if 'identityfile' in host_conf:
                     cfg['key_filename'] = host_conf['identityfile']


### PR DESCRIPTION
Currently an explicitly passed user gets overwritten if there is also one set in the ssh config. This causes problems if one has something like this in his/her ssh config:

```
Host *
  User root
```