### PR TITLE
Config may contain "#", identify prompt by " # " instead of "#"

### DIFF
--- a/pyFG/fortios.py
+++ b/pyFG/fortios.py
@@ -169,7 +169,7 @@ class FortiOS(object):
         # We look for the prompt and remove it
         i = 0
         for line in output:
-            current_line = line.split('#')
+            current_line = line.split(' # ')
 
             if len(current_line) > 1:
                 output[i] = current_line[1]


### PR DESCRIPTION
See #31, prompt recognition in pyFG/fortios.py is done with `line.split('#')`, but the "#" character may also be part of the configuration which can lead to false prompt recognitions.

The CLI prompt in FortiOS 5.2, 5.6 and 6.0 looks as follows (whitespace marked with "_"):
`<hostname>_#_`

So instead of matching with `line.split('#')` this could be matched with line.split(' # ').